### PR TITLE
1.7-1.8 Protocol Hack + Maven and little code changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,66 +14,101 @@
     </properties>
     <repositories>
         <repository>
+        	<!-- SpigotMC Repository (for Bukkit API) -->
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <repository>
+        	<!-- Multiverse-Core Repository -->
             <id>onarandombox</id>
             <url>http://repo.onarandombox.com/content/groups/public</url>
         </repository>
         <repository>
+        	<!-- BungeeCord Repository -->
             <id>bungeecord-repo</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
         <repository>
+        	<!-- Lucko's Repository (needed for BungeeCord-Proxy) -->
             <id>luck-repo</id>
             <url>https://ci.lucko.me/plugin/repository/everything</url>
-        </repository>
+		</repository>
         <repository>
+        	<!-- KCauldron's Repository (needed for Mojang AuthLib) -->
             <id>minecraft-repo</id>
             <url>https://repo.prok.pw</url>
         </repository>
         <repository>
+        	<!-- bStats Repository (needed for Metrics) -->
             <id>bstats-repo</id>
             <url>http://repo.bstats.org/content/repositories/releases/</url>
+        </repository>
+        <repository>
+        	<!-- InventiveTalent's Repository (needed for Spiget-Update) -->
+            <id>inventive-repo</id>
+            <url>https://repo.inventivetalent.org/content/groups/public/</url>
+        </repository>
+        <repository>
+        	<!-- Mikeprimm's Repository (needed for Spigot 1.7.10-1.8.x Protocol Hack compatibility) -->
+        	<id>mikeprimm-repo</id>
+        	<url>http://repo.mikeprimm.com</url>
         </repository>
     </repositories>
     <dependencies>
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
+        	<!-- Bukkit API -->
+            <groupId>org.bukkit</groupId>
+            <artifactId>bukkit</artifactId>
             <version>1.12.2-R0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
+        	<!-- Multiverse-Core (compatibility reasons) -->
             <groupId>com.onarandombox.multiversecore</groupId>
             <artifactId>Multiverse-Core</artifactId>
             <version>2.5.1</version>
         </dependency>
         <dependency>
+        	<!-- BungeeCord API -->
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-api</artifactId>
             <version>1.12-SNAPSHOT</version>
         </dependency>
         <dependency>
+        	<!-- BungeeCord-Proxy (needed for BungeeCord) -->
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-proxy</artifactId>
             <version>1.12-SNAPSHOT</version>
         </dependency>
         <dependency>
+        	<!-- Mojang AuthLib (needed for SkinsGUI) -->
             <groupId>com.mojang</groupId>
             <artifactId>authlib</artifactId>
             <version>1.5.21</version>
         </dependency>
         <dependency>
+        	<!-- bStats Lite (Metrics) for Bukkit -->
             <groupId>org.bstats</groupId>
-            <artifactId>bstats-bukkit</artifactId>
+            <artifactId>bstats-bukkit-lite</artifactId>
             <version>1.2</version>
         </dependency>
         <dependency>
+            <!-- bStats Lite (Metrics) for BungeeCord -->
             <groupId>org.bstats</groupId>
-            <artifactId>bstats-bungeecord</artifactId>
+            <artifactId>bstats-bungeecord-lite</artifactId>
             <version>1.2</version>
         </dependency>
+        <dependency>
+        	<!-- Spiget-Update (for the updater) -->
+        	<groupId>org.inventivetalent.spiget-update</groupId>
+        	<artifactId>bukkit</artifactId>
+        	<version>1.4.0</version>
+    	</dependency>
+    	<dependency>
+    		<!-- Spigot 1.7.10-1.8.x Protocol Hack (for compatibility) -->
+    		<groupId>org.spigotmc</groupId>
+    		<artifactId>spigot</artifactId>
+    		<version>1.7.10-R0.1-SNAPSHOT</version>
+    	</dependency>
     </dependencies>
     <build>
         <plugins>
@@ -90,7 +125,7 @@
                     <relocations>
                         <relocation>
                             <pattern>org.bstats</pattern>
-                            <shadedPattern>skinsrestorer</shadedPattern>
+                            <shadedPattern>skinsrestorer.bStatsMetrics</shadedPattern>
                         </relocation>
                     </relocations>
                 </configuration>

--- a/src/main/java/skinsrestorer/bukkit/SkinsRestorer.java
+++ b/src/main/java/skinsrestorer/bukkit/SkinsRestorer.java
@@ -1,6 +1,6 @@
 package skinsrestorer.bukkit;
 
-import org.bstats.bukkit.Metrics;
+import org.bstats.bukkit.MetricsLite;
 import org.bukkit.Bukkit;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -27,10 +27,7 @@ import skinsrestorer.shared.utils.ReflectionUtil;
 import skinsrestorer.shared.utils.updater.bukkit.SpigetUpdate;
 import skinsrestorer.shared.utils.updater.core.UpdateCallback;
 import skinsrestorer.shared.utils.updater.core.VersionComparator;
-
-import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
-import java.io.File;
+import java.io.*;
 import java.util.List;
 
 public class SkinsRestorer extends JavaPlugin {
@@ -63,7 +60,7 @@ public class SkinsRestorer extends JavaPlugin {
         ConsoleCommandSender console = getServer().getConsoleSender();
 
     	@SuppressWarnings("unused")
-        Metrics metrics = new Metrics(this);
+        MetricsLite metrics = new MetricsLite(this);
         
         SpigetUpdate updater = new SpigetUpdate(this, 2124);
         updater.setVersionComparator(VersionComparator.EQUAL);

--- a/src/main/java/skinsrestorer/bukkit/commands/SrCommand.java
+++ b/src/main/java/skinsrestorer/bukkit/commands/SrCommand.java
@@ -30,7 +30,8 @@ public class SrCommand implements CommandExecutor {
         }
     }
 
-    @Override
+    @SuppressWarnings("deprecation")
+	@Override
     public boolean onCommand(final CommandSender sender, Command arg1, String arg2, String[] args) {
 
         if (sender.hasPermission("skinsrestorer.cmds") || sender.isOp()) {
@@ -52,6 +53,7 @@ public class SrCommand implements CommandExecutor {
                             sb.append(args[i] + " ");
 
                 final String skin = sb.toString();
+                
                 Player player = Bukkit.getPlayer(args[1]);
 
                 if (player == null)
@@ -209,6 +211,7 @@ public class SrCommand implements CommandExecutor {
                             else
                                 name += args[i] + " ";
 
+                    
                     p = Bukkit.getPlayer(name);
 
                     if (p == null) {
@@ -237,22 +240,22 @@ public class SrCommand implements CommandExecutor {
 
                         ConsoleCommandSender cons = Bukkit.getConsoleSender();
 
-                        cons.sendMessage("\n§aName: §8" + name);
-                        cons.sendMessage("\n§aValue : §8" + value);
-                        cons.sendMessage("\n§aSignature : §8" + signature);
+                        cons.sendMessage(C.c("\n&aName: &8" + name));
+                        cons.sendMessage(C.c("\n&aValue : &8" + value));
+                        cons.sendMessage(C.c("\n&aSignature : &8" + signature));
 
                         String decoded = Base64Coder.decodeString(value);
-                        cons.sendMessage("\n§aValue Decoded: §e" + decoded);
+                        cons.sendMessage(C.c("\n&aValue Decoded: &e" + decoded));
 
-                        sender.sendMessage("\n§e" + decoded);
-                        sender.sendMessage("§cMore info in console!");
+                        sender.sendMessage(C.c("\n&e" + decoded));
+                        sender.sendMessage(C.c("&cMore info in console!"));
                     }
                 } catch (Exception e) {
                     e.printStackTrace();
                     sender.sendMessage(Locale.NO_SKIN_DATA);
                     return true;
                 }
-                sender.sendMessage("§cMore info in console!");
+                sender.sendMessage(C.c("&cMore info in console!"));
 
             }
         } else {

--- a/src/main/java/skinsrestorer/bungee/SkinsRestorer.java
+++ b/src/main/java/skinsrestorer/bungee/SkinsRestorer.java
@@ -4,7 +4,7 @@ import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.plugin.Plugin;
-import org.bstats.bungeecord.Metrics;
+import org.bstats.bungeecord.MetricsLite;
 import skinsrestorer.bungee.commands.AdminCommands;
 import skinsrestorer.bungee.commands.PlayerCommands;
 import skinsrestorer.bungee.listeners.LoginListener;
@@ -80,7 +80,7 @@ public class SkinsRestorer extends Plugin {
     public void onEnable() {
     	
         @SuppressWarnings("unused")
-        Metrics metrics = new Metrics(this);
+        MetricsLite metrics = new MetricsLite(this);
         
         SpigetUpdate updater = new SpigetUpdate(this, 2124);
         updater.setVersionComparator(VersionComparator.EQUAL);

--- a/src/main/java/skinsrestorer/shared/storage/SkinStorage.java
+++ b/src/main/java/skinsrestorer/shared/storage/SkinStorage.java
@@ -84,7 +84,8 @@ public class SkinStorage {
      *
      * @return Property object
      **/
-    public static Object getOrCreateSkinForPlayer(final String name) throws SkinRequestException {
+    @SuppressWarnings("deprecation")
+	public static Object getOrCreateSkinForPlayer(final String name) throws SkinRequestException {
         String skin = getPlayerSkin(name);
 
         if (skin == null)


### PR DESCRIPTION
This finally should be the correct PR to be accepted.

**Changes in this PR:**
- Re-added the half-working support for the 1.7.10-1.8.x Protocol Hack that exists on the original developer's repository;
- About Maven: Added the Spigot 1.7.10-1.8.x Protocol Hack jar dependency. Added comments saying what each repository and dependency is, on pom.xml. Also probably removed some useless repository/dependency there;
- About bStats: Changed from bStats (normal) to bStats Lite. Also changed bStats classes to a separated package ("skinsrestorer.bStatsMetrics").
- Suppress deprecated warnings somewhere.

Sorry for so many incorrect PRs.

@DoNotSpamPls
