### PR TITLE
Revival of /skin (name) + unused import + Locale change + README.md change + more

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@
 
  # Note
  This is a fork of the original plugin, refactored to support Maven for easy, automated building and continuous integration.
- Unfortunately, 1.7.10 support had to be removed.
  --------------
  Restoring offline mode skins & changing skins for Spigot/CraftBukkit/BungeeCord/FlexPipe/Waterfall servers
 
- Supported versions: 1.8.x - 1.12.x
+ Supported versions: 1.7.10 (Protocol Hack) - 1.12.x
 
  Spigot Page | [click here](https://www.spigotmc.org/resources/skinsrestorer.2124/)
 

--- a/src/main/java/skinsrestorer/bukkit/commands/GUICommand.java
+++ b/src/main/java/skinsrestorer/bukkit/commands/GUICommand.java
@@ -5,7 +5,6 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import skinsrestorer.bukkit.SkinsRestorer;
 import skinsrestorer.bukkit.menu.SkinsGUI;
 import skinsrestorer.shared.storage.Locale;
 

--- a/src/main/java/skinsrestorer/shared/storage/Locale.java
+++ b/src/main/java/skinsrestorer/shared/storage/Locale.java
@@ -11,7 +11,8 @@ public class Locale {
     public static String PLAYER_HAS_NO_PERMISSION = "&4Error&8: &cYou don't have permission to do this.";
     public static String HELP_PLAYER = "  &2&lSkinsRestorer &7- &f&lv%ver%"
             + "\n    &2/skin set <skinname> &7-&f Changes your skin."
-            + "\n    &2/skin clear &7-&f Clears your skin.";
+    		+ "\n    &2/skin <skinname> &7-&f Shortened version of \"/skin set\"."
+            + "\n    &2/skin clear &7-&f Clears your skin (Bukkit only, at the moment).";
     public static String HELP_SR = "    &2/sr &7- &fDisplay admin commands.";
     public static String NOT_PREMIUM = "&4Error&8: &cPremium player with that name does not exist.";
     public static String SKIN_COOLDOWN_NEW = "&4Error&8: &cYou can change your skin again in &e%s &cseconds.";


### PR DESCRIPTION
**Changes in this PR:**
- Re-added /skin (name), you can now either do "/skin set (name)" or "/skin (name)" to set your skin;
- Removed unused import at GUICommand.java (skinsrestorer.bukkit.commands);
- Changed Locale.java (skinsrestorer.shared.storage) to include "/skin (name)" and to say that "/skin clear" only works on Bukkit, at the moment.
EDIT:
- Change README.md since we now "half-support" the 1.7.10-1.8.x Protocol Hack;
- Add [SkinsRestorer] prefixes on Locale.java (skinsrestorer.shared.storage);
- Remove [SkinsRestorer] hardcoded prefixes.

@DoNotSpamPls
