### PR TITLE
Re-add missing 1.7.10-1.8.x compatibility file + little changes

### DIFF
--- a/src/main/java/skinsrestorer/bukkit/commands/GUICommand.java
+++ b/src/main/java/skinsrestorer/bukkit/commands/GUICommand.java
@@ -1,6 +1,5 @@
 package skinsrestorer.bukkit.commands;
 
-import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/skinsrestorer/bungee/commands/PlayerCommands.java
+++ b/src/main/java/skinsrestorer/bungee/commands/PlayerCommands.java
@@ -11,7 +11,6 @@ import skinsrestorer.shared.storage.Config;
 import skinsrestorer.shared.storage.CooldownStorage;
 import skinsrestorer.shared.storage.Locale;
 import skinsrestorer.shared.storage.SkinStorage;
-import skinsrestorer.shared.utils.C;
 import skinsrestorer.shared.utils.MojangAPI;
 import skinsrestorer.shared.utils.MojangAPI.SkinRequestException;
 import java.util.concurrent.TimeUnit;

--- a/src/main/java/skinsrestorer/bungee/listeners/LoginListener.java
+++ b/src/main/java/skinsrestorer/bungee/listeners/LoginListener.java
@@ -1,5 +1,6 @@
 package skinsrestorer.bungee.listeners;
 
+import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.event.PostLoginEvent;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.event.EventHandler;
@@ -20,12 +21,13 @@ public class LoginListener implements Listener {
     public void onServerChange(final PostLoginEvent e) {
         if (Config.UPDATER_ENABLED && SkinsRestorer.getInstance().isOutdated()
                 && e.getPlayer().hasPermission("skinsrestorer.cmds"))
-            e.getPlayer().sendMessage(C.c(Locale.OUTDATED));
+            e.getPlayer().sendMessage(new TextComponent(C.c(Locale.OUTDATED)));
 
         if (Config.DISABLE_ONJOIN_SKINS)
             return;
 
         if (Config.DEFAULT_SKINS_ENABLED) {
+        	@SuppressWarnings("unused")
             List<String> skins = Config.DEFAULT_SKINS;
             try {
                 SkinStorage.getOrCreateSkinForPlayer(e.getPlayer().getName());


### PR DESCRIPTION
Changes in this PR:
- Re-added SkinFactory_v1_7_R4.java (for some reason it disappeared);
- Removed unused imports;
- Replaced a deprecated line of code on Bungee with a non-deprecated one;
- @SupressWarnings("unused") on a variable on LoginListener.java from Bungee.

@DoNotSpamPls
